### PR TITLE
fix(ts): type def path for SC theme

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "typeRoots": ["./src/ui/themes"]
+    "typeRoots": ["./src/ui/themes/styled.d.ts"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
I've iterated on the theme thing and adding a way to turn dark / light mode. However, the directory referenced in the tsconfig file was too broad and requested to type the sibling folders `hooks` and `components`.

Instead of that, I've made the TS config more narrow and only targeting the specific SC type definition for the theme.